### PR TITLE
add libs to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ python-Levenshtein
 latex
 pdf2image
 loguru
+jpylyzer
+pandas


### PR DESCRIPTION
the libs are needed in the getting_started.ipynb. May be forgotton.